### PR TITLE
Chunked file upload

### DIFF
--- a/src/main/java/com/panxoloto/sharepoint/rest/ChunkFileUploader.java
+++ b/src/main/java/com/panxoloto/sharepoint/rest/ChunkFileUploader.java
@@ -1,0 +1,203 @@
+package com.panxoloto.sharepoint.rest;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.UUID;
+
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import com.panxoloto.sharepoint.rest.helper.AuthTokenHelperOnline;
+import com.panxoloto.sharepoint.rest.helper.HeadersHelper;
+
+public class ChunkFileUploader
+	extends Object
+{
+	private final static Logger            log		= LoggerFactory.getLogger(PLGSharepointClientOnline.class);
+	private final static ByteArrayResource empty	= new ChunkResource(new byte[] {});
+	
+	private final HeadersHelper			headerHelper;
+	private final AuthTokenHelperOnline	tokenHelper;
+	private final RestTemplate			restTemplate;	
+	
+	ChunkFileUploader( final AuthTokenHelperOnline tokenHelper )
+	{
+		super();
+		this.tokenHelper	= tokenHelper;
+		this.restTemplate	= new RestTemplate();
+		this.headerHelper	= new HeadersHelper(this.tokenHelper);
+	}
+	
+	protected long startFileUpload(final String uploadId, final String pathToTargetFile, final Resource resource)
+		throws Exception
+	{
+		final long size = resource.contentLength();
+		final String response = this.execute
+		(
+			"/_api/web/getFileByServerRelativeUrl('" + pathToTargetFile + "')/startupload(uploadId=guid'" + uploadId + "')",
+			resource
+		);		
+	    final long bytesWritten = Long.parseLong( new JSONObject(response).getJSONObject("d").getString("StartUpload") );
+	    if ( bytesWritten!=resource.contentLength() ) 
+	    {
+	    	throw new Exception( "Start chunk has not been transmitted completely [" + bytesWritten +"/" + size + "]" );
+	    }
+	    return bytesWritten;
+	}
+
+	protected long continueFileUpload
+	(
+		final String uploadId, final String pathToTargetFile, final long offset, final Resource resource
+	)
+		throws Exception
+	{		
+	    final String uri = "/_api/web/getFileByServerRelativeUrl('" + pathToTargetFile + "')/continueupload(uploadId=guid'" + uploadId + "', fileOffset=" + offset + ")";
+		final String response = this.execute(uri, resource);
+	    return Long.parseLong( new JSONObject(response).getJSONObject("d").getString("ContinueUpload") );
+	}
+	
+	protected JSONObject finishFileUpload
+	(
+		final String uploadId, final String pathToTargetFile, final long offset, final Resource resource
+	)
+		throws Exception
+	{		
+	    final String uri = "/_api/web/getFileByServerRelativeUrl('" + pathToTargetFile + "')/finishupload(uploadId=guid'" + uploadId + "', fileOffset=" + offset + ")";
+		final String response = this.execute(uri, resource);
+	    return new JSONObject(response);
+	}
+	
+	public JSONObject uploadFile( final String folder, final Resource resource, final int size ) 
+		throws Exception 
+	{
+		final String filename = resource.getFilename();
+		log.debug("Uploading file {} to folder {}", filename, folder);
+			
+		final String id = UUID.randomUUID().toString();
+		final String pathToTargetFile = folder + "/" + filename;
+		this.createNewEmptyFile(folder, filename);
+		log.debug("empty file {} has been created in folder {}", filename, folder);
+
+		long offset = 0L;
+		final byte[] buffer = new byte[size];
+		try ( final InputStream is = resource.getInputStream() )
+		{
+			for ( int readBytes=is.read(buffer); readBytes!=-1; readBytes = is.read(buffer) )
+			{
+				log.debug("offset [" + offset + "] got [" + readBytes + "] bytes");
+				final ChunkResource chunkResource = new ChunkResource(filename, buffer, readBytes); 
+				if ( offset==0 )
+				{
+					offset = this.startFileUpload(id, pathToTargetFile, chunkResource);
+				}
+				else
+				{
+					offset = this.continueFileUpload(id, pathToTargetFile, offset, chunkResource);
+				}
+			}
+		}
+		return this.finishFileUpload(id, pathToTargetFile, offset, empty);
+	}
+	
+	protected final JSONObject createNewEmptyFile( final String folder, final String newFileName )
+		throws Exception
+	{
+		log.debug("creating new empty file {} to folder {}", newFileName, folder);
+		final String fileInfoStr = this.execute
+	    ( 
+	    	"/_api/web/GetFolderByServerRelativeUrl('" + folder +"')/Files/add(url='" + newFileName + "',overwrite=true)",	
+	    	empty
+	    );
+	    return new JSONObject(fileInfoStr);
+	}
+
+	private final String execute( final String call, final Resource resource )
+		throws URISyntaxException
+	{
+		final RequestEntity<Resource> request = this.requestEntity(call, resource);
+	    final ResponseEntity<String> responseEntity = this.restTemplate.exchange(request, String.class);
+	    final String response = responseEntity.getBody();
+	    log.debug("json response from server :" );
+	    log.debug( response );
+	    return response;
+	}
+	
+	private final RequestEntity<Resource> requestEntity( final String call, final Resource resource )
+		throws URISyntaxException
+	{
+	    return new RequestEntity<>
+	    (
+	    	resource, 
+	        headers(), 
+	        HttpMethod.POST, 
+	        this.uri(call)
+	    );
+	}
+	
+	private final URI uri(final String call)
+		throws URISyntaxException
+	{
+        return this.tokenHelper.getSharepointSiteUrl(call);
+	}
+	
+	private final MultiValueMap<String, String> headers()
+	{
+		final MultiValueMap<String, String> headers = headerHelper.getPostHeaders("");
+	    headers.remove("Content-Length");
+	    return headers;
+	}
+	
+	public static class ChunkResource
+		extends ByteArrayResource
+	{
+		private final String filename;
+		private final int    size;
+
+		ChunkResource( final byte[] bytes )
+		{
+			this("dummy", bytes, bytes.length);
+		}
+		
+		ChunkResource( final byte[] bytes, final int size )
+		{
+			this("dummy", bytes, size);
+		}
+		
+		ChunkResource( final String filename, final byte[] bytes, final int size )
+		{
+			super(bytes);
+			this.filename	= filename;
+			this.size		= size;
+		}
+
+		@Override
+		public final String getFilename() 
+		{
+			return this.filename;
+		}
+
+		@Override
+		public long contentLength() 
+		{
+			return this.size;
+		}
+
+		@Override
+		public InputStream getInputStream() 
+			throws IOException 
+		{
+			return new ByteArrayInputStream(this.getByteArray(), 0, this.size);
+		}
+	}
+}

--- a/src/main/java/com/panxoloto/sharepoint/rest/ChunkFileUploader.java
+++ b/src/main/java/com/panxoloto/sharepoint/rest/ChunkFileUploader.java
@@ -77,6 +77,19 @@ public class ChunkFileUploader
 		final String response = this.execute(uri, resource);
 	    return new JSONObject(response);
 	}
+
+	protected void cancelFileUploadSilently( final String uploadId, final String pathToTargetFile )
+	{		
+		try
+		{
+		    final String uri = "/_api/web/getFileByServerRelativeUrl('" + pathToTargetFile + "')/cancelupload(uploadId=guid'" + uploadId + "')";
+			this.execute(uri, null);
+		}
+		catch( final Exception e )
+		{
+			log.error("Could not cancel chunkedUpload", e );
+		}
+	}
 	
 	public JSONObject uploadFile( final String folder, final Resource resource, final int size ) 
 		throws Exception 

--- a/src/main/java/com/panxoloto/sharepoint/rest/PLGSharepointClientOnline.java
+++ b/src/main/java/com/panxoloto/sharepoint/rest/PLGSharepointClientOnline.java
@@ -687,4 +687,9 @@ public class PLGSharepointClientOnline implements PLGSharepointClient {
 	    return Boolean.TRUE;
 	}
 
+	public final ChunkFileUploader createChunkFileUploader()
+	{
+		return new ChunkFileUploader(this.tokenHelper);
+	}
+	
 }


### PR DESCRIPTION
By default it is possible to upload files up to 262144000 bytes.
If file is bigger then the following exception occurs :

```
org.springframework.web.client.HttpClientErrorException$BadRequest: 400 Bad Request: [{"error":{"code":"-1, Microsoft.SharePoint.Client.InvalidClientQueryException","message":{"lang":"en-US","value":"The request message is too big. The server does not allow messages larger than 262144000 bytes."}}}]
	at org.springframework.web.client.HttpClientErrorException.create(HttpClientErrorException.java:101)[https://editportal.netrtl.com:443/edit-portal/webstart/spring-web-5.2.3.RELEASE.jar:5.2.3.RELEASE]
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:170)[https://editportal.netrtl.com:443/edit-portal/webstart/spring-web-5.2.3.RELEASE.jar:5.2.3.RELEASE]
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:112)[https://editportal.netrtl.com:443/edit-portal/webstart/spring-web-5.2.3.RELEASE.jar:5.2.3.RELEASE]
	at org.springframework.web.client.ResponseErrorHandler.handleError(ResponseErrorHandler.java:63)[https://editportal.netrtl.com:443/edit-portal/webstart/spring-web-5.2.3.RELEASE.jar:5.2.3.RELEASE]
	at org.springframework.web.client.RestTemplate.handleResponse(RestTemplate.java:785)[https://editportal.netrtl.com:443/edit-portal/webstart/spring-web-5.2.3.RELEASE.jar:5.2.3.RELEASE]
	at org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:743)[https://editportal.netrtl.com:443/edit-portal/webstart/spring-web-5.2.3.RELEASE.jar:5.2.3.RELEASE]
	at org.springframework.web.client.RestTemplate.exchange(RestTemplate.java:644)[https://editportal.netrtl.com:443/edit-portal/webstart/spring-web-5.2.3.RELEASE.jar:5.2.3.RELEASE]
	at com.panxoloto.sharepoint.rest.PLGSharepointClientOnline.uploadFile(PLGSharepointClientOnline.java:377)[https://editportal.netrtl.com:443/edit-portal/webstart/sharepoint-rest-api-1.0.3.jar:]
	at com.cbc.vfs2.povider.sharepoint.SharePointFileObject.lambda$doGetOutputStream$0(SharePointFileObject.java:210)[https://editportal.netrtl.com:443/edit-portal/webstart/commons-vfs2-sharepoint-0.0.2.jar:]
	at java.lang.Thread.run(Thread.java:748)[:1.8.0_202]
```
 To bypass this limitation chunked file upload may be used.
