### PR TITLE
Parser for Authentication (token) response & error handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,14 +82,12 @@
             <artifactId>junit</artifactId>
             <version>4.13.1</version>
         </dependency>
-        
-		<dependency>
-			<groupId>org.testng</groupId>
-			<artifactId>testng</artifactId>
-			<version>7.3.0</version>
-			<scope>test</scope>
-		</dependency>		
-        
+        <dependency>
+        	<groupId>org.testng</groupId>
+        	<artifactId>testng</artifactId>
+        	<version>7.3.0</version>
+        	<scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,14 @@
             <artifactId>junit</artifactId>
             <version>4.13.1</version>
         </dependency>
+        
+		<dependency>
+			<groupId>org.testng</groupId>
+			<artifactId>testng</artifactId>
+			<version>7.3.0</version>
+			<scope>test</scope>
+		</dependency>		
+        
     </dependencies>
 
 </project>

--- a/src/main/java/com/panxoloto/sharepoint/rest/PLGSharepointClientOnline.java
+++ b/src/main/java/com/panxoloto/sharepoint/rest/PLGSharepointClientOnline.java
@@ -38,7 +38,7 @@ public class PLGSharepointClientOnline implements PLGSharepointClient {
 	 * @param spSiteUrl - The sharepoint site URI like /sites/contososite
 	 */
 	public PLGSharepointClientOnline(String user, 
-			String passwd, String domain, String spSiteUrl) {
+			String passwd, String domain, String spSiteUrl) throws Exception {
 		super();
 		this.restTemplate = new RestTemplate();
 		this.spSiteUrl = spSiteUrl;
@@ -51,13 +51,8 @@ public class PLGSharepointClientOnline implements PLGSharepointClient {
 			this.spSiteUrl = String.format("%s%s", "/", this.spSiteUrl);
 		}
 		this.tokenHelper = new AuthTokenHelperOnline(this.restTemplate, user, passwd, domain, spSiteUrl);
-		try {
-			LOG.debug("Wrapper auth initialization performed successfully. Now you can perform actions on the site.");
-			this.tokenHelper.init();
-			this.headerHelper = new HeadersHelper(this.tokenHelper);
-		} catch (Exception e) {
-			LOG.error("Initialization failed!! Please check the user, pass, domain and spSiteUri parameters you provided", e);
-		}
+		this.tokenHelper.init();
+		this.headerHelper = new HeadersHelper(this.tokenHelper);
 	}
 
 	/**

--- a/src/main/java/com/panxoloto/sharepoint/rest/helper/AuthTokenHelperOnline.java
+++ b/src/main/java/com/panxoloto/sharepoint/rest/helper/AuthTokenHelperOnline.java
@@ -83,20 +83,14 @@ public class AuthTokenHelperOnline {
 	}
 	
 	
-	protected String receiveSecurityToken() throws URISyntaxException {
+	protected String receiveSecurityToken() throws URISyntaxException, AuthenticationException {
 		RequestEntity<String> requestEntity = 
 	        new RequestEntity<>(this.payload, 
 	        HttpMethod.POST, 
 	        new URI(TOKEN_LOGIN_URL));
 
 	    ResponseEntity<String> responseEntity = restTemplate.exchange(requestEntity, String.class);
-		String securityToken = responseEntity.getBody();
-		String clave1 = "<wsse:BinarySecurityToken";
-		String clave2 = "</wsse:BinarySecurityToken>";
-		securityToken = securityToken.substring(securityToken.indexOf(clave1));
-		securityToken = securityToken.substring(securityToken.indexOf(">") + 1);
-		securityToken = securityToken.substring(0, securityToken.indexOf(clave2));
-		return securityToken;
+		return AuthenticationResponseParser.parseAuthenticationResponse(responseEntity.getBody());
 	}
 
 	protected List<String> getSignInCookies(String securityToken)

--- a/src/main/java/com/panxoloto/sharepoint/rest/helper/AuthenticationException.java
+++ b/src/main/java/com/panxoloto/sharepoint/rest/helper/AuthenticationException.java
@@ -1,0 +1,30 @@
+package com.panxoloto.sharepoint.rest.helper;
+
+import javax.xml.soap.SOAPFault;
+
+public class AuthenticationException
+	extends RuntimeException
+{
+	private static final long serialVersionUID = 1L;
+
+	public final SOAPFault reason;
+	
+	public AuthenticationException( final String message, final Throwable cause ) 
+	{
+		super(message, cause);
+		this.reason = null;
+	}
+
+	public AuthenticationException(final String message) 
+	{
+		super(message);
+		this.reason = null;
+	}
+	
+	public AuthenticationException( final SOAPFault fault ) 
+	{
+		super("Authentication has failed : " + fault.getFaultString());
+		this.reason = fault;
+	}
+	
+}

--- a/src/main/java/com/panxoloto/sharepoint/rest/helper/AuthenticationResponseParser.java
+++ b/src/main/java/com/panxoloto/sharepoint/rest/helper/AuthenticationResponseParser.java
@@ -1,0 +1,68 @@
+package com.panxoloto.sharepoint.rest.helper;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+
+import javax.xml.namespace.QName;
+import javax.xml.soap.MessageFactory;
+import javax.xml.soap.SOAPBody;
+import javax.xml.soap.SOAPConstants;
+import javax.xml.soap.SOAPException;
+import javax.xml.soap.SOAPFault;
+import javax.xml.soap.SOAPMessage;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class AuthenticationResponseParser
+	extends Object
+{
+	public final static Charset utf8 = Charset.forName("utf8");
+	public final static QName binarySecurityTokenName = new QName
+	(
+		"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd", "BinarySecurityToken"
+	);
+	
+	public final static String  parseAuthenticationResponse( final String response )
+		throws AuthenticationException 
+	{
+		try ( final InputStream is = new ByteArrayInputStream(response.getBytes(utf8)) )
+		{
+			final MessageFactory	f		= MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL);
+			final SOAPMessage		m		= f.createMessage(null, is);
+			final SOAPBody			body	= m.getSOAPBody();
+			final SOAPFault			fault	= body.getFault();
+			if ( fault!=null )
+			{
+				throw new AuthenticationException(fault);
+			}
+			return token(body);
+		}
+		catch( final SOAPException soapExc )
+		{
+			throw new AuthenticationException("Could not parse authentication response : " + soapExc.getMessage(), soapExc);
+		}
+		catch( final IOException ioExc )
+		{
+			throw new AuthenticationException("Unexpected IO exception occured", ioExc);
+		}
+	}
+	
+	private final static String token( final SOAPBody body )
+	{
+		final NodeList list=body.getElementsByTagNameNS(binarySecurityTokenName.getNamespaceURI(), binarySecurityTokenName.getLocalPart());
+		if ( list.getLength()>0 )
+		{
+			final Node node = list.item(0);
+			if ( node instanceof Element )
+			{
+				final Element tokenEl = (Element)node;
+				return tokenEl.getTextContent();
+			}
+		}
+		throw new AuthenticationException("Authentication response does not contain mandatory element " + binarySecurityTokenName);
+	}
+}

--- a/src/test/java/com/panxoloto/sharepoint/rest/helper/EnvelopParserTest.java
+++ b/src/test/java/com/panxoloto/sharepoint/rest/helper/EnvelopParserTest.java
@@ -1,0 +1,80 @@
+package com.panxoloto.sharepoint.rest.helper;
+import java.io.CharArrayWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+
+import org.testng.annotations.Test;
+
+import com.panxoloto.sharepoint.rest.helper.AuthenticationException;
+import com.panxoloto.sharepoint.rest.helper.AuthenticationResponseParser;
+
+public class EnvelopParserTest
+	extends Object
+{
+	public final static String soapEnvelopeNamespace = "http://www.w3.org/2003/05/soap-envelope";
+	
+	@Test
+	(
+		expectedExceptions = AuthenticationException.class,
+		expectedExceptionsMessageRegExp = "Authentication has failed : Authentication Failure"
+	)
+	public final void soapTest_message_with_Fault()
+		throws Exception
+	{
+		final String response = charsUtf8("com/panxoloto/sharepoint/rest/helper/authentication-error-response.xml");
+		AuthenticationResponseParser.parseAuthenticationResponse(response);
+	}
+
+	@Test
+	(
+		expectedExceptions = AuthenticationException.class,
+		expectedExceptionsMessageRegExp = "Could not parse authentication response : Unable to create envelope from given source: "
+	)
+	public final void soapTest_not_a_soap_message()
+		throws Exception
+	{
+		AuthenticationResponseParser.parseAuthenticationResponse("<root></root>");
+	}
+
+	@Test
+	public final void soapTest_withSequrityToken()
+		throws Exception
+	{
+		final String response = charsUtf8("com/panxoloto/sharepoint/rest/helper/authentication-success-response.xml");
+		final String token = AuthenticationResponseParser.parseAuthenticationResponse(response);
+		assert "t=TOKENp=".equals(token);
+	}
+	
+	public static String charsUtf8(	final String resource ) 
+		throws IOException
+	{
+		return chars(resource, AuthenticationResponseParser.utf8);
+	}
+	
+	public static String chars
+	(
+		final String resource, final Charset cs
+	) 
+		throws IOException
+	{
+		try ( final InputStream is = EnvelopParserTest.class.getClassLoader().getResourceAsStream(resource) )
+		{
+			try ( final Reader r = new InputStreamReader(is, cs) )
+			{
+				try ( CharArrayWriter w = new CharArrayWriter() )
+				{
+					final char[] b = new char[10000];
+					int charsWereRead = 0;
+					while ( (charsWereRead = r.read(b))!=-1 )
+					{
+						w.write(b, 0, charsWereRead);
+					}
+					return new String(w.toCharArray());
+				}
+			}
+		}
+	}
+}

--- a/src/test/resources/com/panxoloto/sharepoint/rest/helper/authentication-error-response.xml
+++ b/src/test/resources/com/panxoloto/sharepoint/rest/helper/authentication-error-response.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<S:Envelope xmlns:wsa="http://www.w3.org/2005/08/addressing" 
+						xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" 
+						xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" 
+						xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" 
+						xmlns:wst="http://schemas.xmlsoap.org/ws/2005/02/trust" 
+						xmlns:S="http://www.w3.org/2003/05/soap-envelope">
+<S:Header>
+	<psf:pp xmlns:psf="http://schemas.microsoft.com/Passport/SoapServices/SOAPFault">
+		<psf:serverVersion>1</psf:serverVersion>
+		<psf:authstate>0x80048800</psf:authstate>
+		<psf:reqstatus>0x80048821</psf:reqstatus>
+		<psf:serverInfo ServerTime="2021-03-05T11:28:03.2156309Z">ESTS-PUB-WEULR2-AZ1-FD059-001.ProdSlices rid:033f82dd-cae8-43e1-bd95-d3921cf31400</psf:serverInfo>
+	</psf:pp>
+	</S:Header>
+		<S:Body xmlns:S="http://www.w3.org/2003/05/soap-envelope">
+			<S:Fault>
+				<S:Code>
+					<S:Value>S:Sender</S:Value>
+					<S:Subcode><S:Value>wst:FailedAuthentication</S:Value></S:Subcode>
+				</S:Code>
+				<S:Reason>
+					<S:Text xml:lang="en-US">Authentication Failure</S:Text>
+				</S:Reason>
+				<S:Detail>
+					<psf:error xmlns:psf="http://schemas.microsoft.com/Passport/SoapServices/SOAPFault">
+						<psf:value>0x80048821</psf:value>
+						<psf:internalerror>
+							<psf:code>0x80048821</psf:code>
+							<psf:text>AADSTS50126: Error validating credentials due to invalid username or password.</psf:text>
+						</psf:internalerror>
+					</psf:error>
+				</S:Detail>
+			</S:Fault>
+	</S:Body>
+</S:Envelope>

--- a/src/test/resources/com/panxoloto/sharepoint/rest/helper/authentication-success-response.xml
+++ b/src/test/resources/com/panxoloto/sharepoint/rest/helper/authentication-success-response.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<S:Envelope xmlns:wsa="http://www.w3.org/2005/08/addressing" 
+            xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" 
+            xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" 
+            xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" 
+            xmlns:wst="http://schemas.xmlsoap.org/ws/2005/02/trust" 
+            xmlns:S="http://www.w3.org/2003/05/soap-envelope">
+<S:Header>
+	<wsa:Action S:mustUnderstand="1" wsu:Id="Action">http://schemas.xmlsoap.org/ws/2005/02/trust/RSTR/Issue</wsa:Action>
+	<wsa:To S:mustUnderstand="1" wsu:Id="To">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+	<wsse:Security S:mustUnderstand="1">
+		<wsu:Timestamp wsu:Id="TS" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+			<wsu:Created>2021-03-05T11:37:27.7367086Z</wsu:Created>
+			<wsu:Expires>2021-03-05T11:42:27.7367086Z</wsu:Expires>
+		</wsu:Timestamp>
+	</wsse:Security>
+</S:Header>
+<S:Body xmlns:S="http://www.w3.org/2003/05/soap-envelope">
+	<wst:RequestSecurityTokenResponse xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" 
+	                                  xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" 
+	                                  xmlns:wst="http://schemas.xmlsoap.org/ws/2005/02/trust"
+	>
+		<wst:TokenType>urn:passport:compact</wst:TokenType>
+		<wsp:AppliesTo>
+			<wsa:EndpointReference xmlns:wsa="http://www.w3.org/2005/08/addressing">
+				<wsa:Address>rtlde.sharepoint.com</wsa:Address>
+			</wsa:EndpointReference>
+		</wsp:AppliesTo>
+		<wst:Lifetime>
+			<wsu:Created>2021-03-05T11:37:27Z</wsu:Created>
+			<wsu:Expires>2021-03-06T11:37:27Z</wsu:Expires>
+		</wst:Lifetime>
+		<wst:RequestedSecurityToken>
+			<wsse:BinarySecurityToken Id="Compact0" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">t=TOKENp=</wsse:BinarySecurityToken>
+		</wst:RequestedSecurityToken>
+				
+				<wst:RequestedAttachedReference>
+					<wsse:SecurityTokenReference xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+						<wsse:Reference URI="sVHsxUuWKJY/r868iY29Z2dqBZU="></wsse:Reference>
+					</wsse:SecurityTokenReference>
+				</wst:RequestedAttachedReference>
+				
+				<wst:RequestedUnattachedReference>
+					<wsse:SecurityTokenReference xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+						<wsse:Reference URI="sVHsxUuWKJY/r868iY29Z2dqBZU="></wsse:Reference>
+					</wsse:SecurityTokenReference>
+				</wst:RequestedUnattachedReference>
+				
+				
+	</wst:RequestSecurityTokenResponse>
+</S:Body>
+</S:Envelope>


### PR DESCRIPTION
Currently if caller supplies incorrect user credentials instantiation of PLGSharepointClientOnline reports no error whereas  any subsequent operation fails with NullPointerException.

New class AuthenticationResponseParser parses authentication response as a SOAP message, checks if request succeeded 
and throws AuthenticationException otherwise.

 I think this approach is a little bit more understandable and transparent for the caller.