### PR TITLE
Dependantbot security fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,6 @@
 			<artifactId>spring-web</artifactId>
 			<version>${spring.framework}</version>
 		</dependency>
-		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-mapper-asl</artifactId>
-			<version>1.9.4</version>
-		</dependency>
 		<!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
 		<dependency>
 			<groupId>commons-io</groupId>
@@ -71,12 +66,12 @@
 			<artifactId>json</artifactId>
 			<version>20180813</version>
 		</dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>22.0</version>
-            <scope>compile</scope>
-        </dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>[30.0-jre,)</version>
+			<scope>compile</scope>
+		</dependency>
         <dependency>
         	<groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
guava updated to a latests version due to security bugs on current used version.
Removed jackson-mapper-asl dependency as it is not currently needed.