### PR TITLE
support higher java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,31 +32,28 @@
 			<organizationUrl>http://github.com/kikovalle</organizationUrl>
 		</developer>
 	</developers>
-
+	
 	<properties>
-		<java.version>8</java.version> <!-- Replaces source/target-->
+		<java.version>17</java.version> <!-- Replaces source/target/ Spring Framework 6.1.x: JDK 17-23-->
 
 		<!-- Dependencies -->
-		<spring.framework>6.0.0</spring.framework>
-		<serializer.version>2.8.1</serializer.version>
-		<httpclient.version>5.1.3</httpclient.version>
-		<commons-io.version>2.11.0</commons-io.version>
-		<slf4j-api.version>2.0.2</slf4j-api.version>
-		<json.version>20220924</json.version>
-		<guava.version>[31.1-jre,)</guava.version>
+		<spring.framework>6.1.14</spring.framework>
+		<httpclient.version>5.4</httpclient.version>
+		<commons-io.version>2.17.0</commons-io.version>
+		<slf4j-api.version>2.0.16</slf4j-api.version>
+		<json.version>20240303</json.version>
+		<guava.version>33.3.1-jre</guava.version>
 		<junit.version>4.13.2</junit.version>
-		<testng.version>7.6.1</testng.version> <!-- 7.6.1 has vulnerabilities from SnakeYAML 1.30 -->
-		<snakeyaml.version>1.33</snakeyaml.version> <!-- Temporary replacement dependency -->
-		<gson.version>2.9.1</gson.version>
-		<httpmime.version>4.5.13</httpmime.version>
-		<jakarta.xml.ws.version>4.0.0</jakarta.xml.ws.version>
+		<testng.version>7.10.2</testng.version>
+		<gson.version>2.11.0</gson.version>
+		<jakarta.xml.ws.version>4.0.2</jakarta.xml.ws.version>
 
 		<!-- Plugins -->
-		<maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-		<maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
-		<maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
-		<nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
-		<maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+		<maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+		<maven-javadoc-plugin.version>3.10.1</maven-javadoc-plugin.version>
+		<maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+		<nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
+		<maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
 	</properties>
 
 	<build>
@@ -170,31 +167,12 @@
 			<artifactId>testng</artifactId>
 			<version>${testng.version}</version>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<!-- This 1.30 dependency have several vulnerabilities-->
-					<groupId>org.yaml</groupId>
-					<artifactId>snakeyaml</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
-		<!-- This version does not have any known vulnerabilities atm. related to the SnakeYAML dependency in TestNG	-->
-		<dependency>
-			<groupId>org.yaml</groupId>
-			<artifactId>snakeyaml</artifactId>
-			<version>${snakeyaml.version}</version>
-		</dependency>
-
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<version>${gson.version}</version>
 			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpmime</artifactId>
-			<version>${httpmime.version}</version>
 		</dependency>
 		<dependency>
 			<!-- JDK 11+ dependency	-->

--- a/src/main/java/com/panxoloto/sharepoint/rest/PLGSharepointClientOnline.java
+++ b/src/main/java/com/panxoloto/sharepoint/rest/PLGSharepointClientOnline.java
@@ -7,9 +7,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -681,7 +681,7 @@ public class PLGSharepointClientOnline implements PLGSharepointClient {
 
     @Override
     public JSONObject moveFolder(String sourceRelativeServerUrl, String destinyRelativeServerUrl) throws Exception {
-        LOG.debug("createFolder sourceRelativeServerUrl {} destinyRelativeServerUrl {}", sourceRelativeServerUrl, destinyRelativeServerUrl);
+        LOG.debug("moveFolder sourceRelativeServerUrl {} destinyRelativeServerUrl {}", sourceRelativeServerUrl, destinyRelativeServerUrl);
         headers = headerHelper.getPostHeaders("");
 
         RequestEntity<String> requestEntity = new RequestEntity<>("",
@@ -703,7 +703,7 @@ public class PLGSharepointClientOnline implements PLGSharepointClient {
      */
     @Override
     public JSONObject moveFile(String sourceRelativeServerUrl, String destinyRelativeServerUrl) throws Exception {
-        LOG.debug("createFolder sourceRelativeServerUrl {} destinyRelativeServerUrl {}", sourceRelativeServerUrl, destinyRelativeServerUrl);
+        LOG.debug("moveFile sourceRelativeServerUrl {} destinyRelativeServerUrl {}", sourceRelativeServerUrl, destinyRelativeServerUrl);
         headers = headerHelper.getPostHeaders("");
 
         RequestEntity<String> requestEntity = new RequestEntity<>("",

--- a/src/main/java/com/panxoloto/sharepoint/rest/StreamRestTemplate.java
+++ b/src/main/java/com/panxoloto/sharepoint/rest/StreamRestTemplate.java
@@ -12,7 +12,7 @@ import java.util.List;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRequest;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestFactory;
@@ -91,13 +91,13 @@ public class StreamRestTemplate extends RestTemplate {
 		private boolean isStream = false;
 
 		@Override
-		public HttpStatus getStatusCode() throws IOException {
+		public HttpStatusCode getStatusCode() throws IOException {
 			return delegate.getStatusCode();
 		}
 
 		@Override
 		public int getRawStatusCode() throws IOException {
-			return delegate.getRawStatusCode();
+			return delegate.getStatusCode().value();
 		}
 
 		@Override

--- a/src/main/java/com/panxoloto/sharepoint/rest/helper/AuthTokenHelperOnline.java
+++ b/src/main/java/com/panxoloto/sharepoint/rest/helper/AuthTokenHelperOnline.java
@@ -10,8 +10,8 @@ import java.util.stream.Collectors;
 
 import javax.xml.transform.TransformerException;
 
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;

--- a/src/main/java/com/panxoloto/sharepoint/rest/helper/HeadersOnPremiseHelper.java
+++ b/src/main/java/com/panxoloto/sharepoint/rest/helper/HeadersOnPremiseHelper.java
@@ -1,6 +1,6 @@
 package com.panxoloto.sharepoint.rest.helper;
 
-import org.apache.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 


### PR DESCRIPTION
- fix error on master 'The method setHttpClient(HttpClient) in the type HttpComponentsClientHttpRequestFactory is not applicable for the arguments (CloseableHttpClient)',
- in spring version to 6.1.14 and other Dependencies version
- Java version support as Spring Framework 6.1.x: JDK 17 to 23